### PR TITLE
BT-1592

### DIFF
--- a/src/LoginView.js
+++ b/src/LoginView.js
@@ -146,10 +146,12 @@ export default class LoginView extends PureComponent {
       renderExitButton,
       onFail,
       containerStyle,
+      tokenState,
       ...rest
     } = this.props;
 
-    if (!loaded) {
+    // If there exists a refresh token to not show the login screen
+    if (!loaded || tokenState.refresh) {
       return renderLoading();
     }
 

--- a/tests/LoginView.test.js
+++ b/tests/LoginView.test.js
@@ -17,6 +17,7 @@ describe("LoginView", () => {
     onFail: jest.fn(),
     secureStore: jest.fn(),
     renderExitButton: jest.fn(),
+    tokenState: { refresh: "" },
     onError: jest.fn(),
     renderLoading: () => <Text>loading</Text>
   };


### PR DESCRIPTION
Add a check on any refresh token to `renderLoading` for rendering. Handling the logic of an invalid token is handled in other place.

Manually tested with an invalid access token.  

